### PR TITLE
Add a CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
 /Dockerfile @exercism/ops
+/.dockerignore @exercism/ops
 /.github/CODEOWNERS @exercism/ops

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 /Dockerfile @exercism/ops
+/.github/CODEOWNERS @exercism/ops

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/Dockerfile @exercism/ops


### PR DESCRIPTION
Add a CODEOWNERS file to protect merges to the Dockerfile from anyone who is not part of the @exercism/ops.