### PR TITLE
Return multiple comments for two-fer

### DIFF
--- a/src/Exercism.Analyzers.CSharp/Analyzers/TwoFer/TwoFerAnalyzer.cs
+++ b/src/Exercism.Analyzers.CSharp/Analyzers/TwoFer/TwoFerAnalyzer.cs
@@ -81,7 +81,7 @@ namespace Exercism.Analyzers.CSharp.Analyzers.TwoFer
                 return twoFerSolution.ApproveWithComment(comments.ToArray());
 
             if (twoFerSolution.ReturnsStringInterpolationWithDefaultValue() ||
-                    twoFerSolution.ReturnsStringInterpolationWithNullCoalescingOperator())
+                twoFerSolution.ReturnsStringInterpolationWithNullCoalescingOperator())
                 return twoFerSolution.ApproveAsOptimal();
 
             return null;

--- a/src/Exercism.Analyzers.CSharp/Analyzers/TwoFer/TwoFerAnalyzer.cs
+++ b/src/Exercism.Analyzers.CSharp/Analyzers/TwoFer/TwoFerAnalyzer.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Linq;
 using static Exercism.Analyzers.CSharp.Analyzers.Shared.SharedComments;
 using static Exercism.Analyzers.CSharp.Analyzers.TwoFer.TwoFerComments;
 
@@ -15,32 +17,34 @@ namespace Exercism.Analyzers.CSharp.Analyzers.TwoFer
 
         private static SolutionAnalysis DisapproveWhenInvalid(this TwoFerSolution twoFerSolution)
         {
+            var comments = new List<string>();
+
             if (twoFerSolution.UsesOverloads)
-                return twoFerSolution.DisapproveWithComment(UseSingleFormattedStringNotMultiple);
+                comments.Add(UseSingleFormattedStringNotMultiple);
 
             if (twoFerSolution.MissingSpeakMethod ||
                 twoFerSolution.InvalidSpeakMethod)
-                return twoFerSolution.DisapproveWithComment(FixCompileErrors);
+                comments.Add(FixCompileErrors);
 
             if (twoFerSolution.UsesDuplicateString)
-                return twoFerSolution.DisapproveWithComment(UseSingleFormattedStringNotMultiple);
+                comments.Add(UseSingleFormattedStringNotMultiple);
 
             if (twoFerSolution.NoDefaultValue)
-                return twoFerSolution.DisapproveWithComment(UseDefaultValue);
+                comments.Add(UseDefaultValue);
 
             if (twoFerSolution.InvalidDefaultValue)
-                return twoFerSolution.DisapproveWithComment(InvalidDefaultValue);
+                comments.Add(InvalidDefaultValue);
 
             if (twoFerSolution.UsesStringReplace)
-                return twoFerSolution.DisapproveWithComment(UseStringInterpolationNotStringReplace);
+                comments.Add(UseStringInterpolationNotStringReplace);
 
             if (twoFerSolution.UsesStringJoin)
-                return twoFerSolution.DisapproveWithComment(UseStringInterpolationNotStringJoin);
+                comments.Add(UseStringInterpolationNotStringJoin);
 
             if (twoFerSolution.UsesStringConcat)
-                return twoFerSolution.DisapproveWithComment(UseStringInterpolationNotStringConcat);
+                comments.Add(UseStringInterpolationNotStringConcat);
 
-            return null;
+            return comments.Any() ? twoFerSolution.DisapproveWithComment(comments.ToArray()) : null;
         }
 
         private static SolutionAnalysis ApproveWhenValid(this TwoFerSolution twoFerSolution) =>
@@ -53,28 +57,32 @@ namespace Exercism.Analyzers.CSharp.Analyzers.TwoFer
             if (!twoFerSolution.UsesSingleLine())
                 return null;
 
-            if (twoFerSolution.ReturnsStringInterpolationWithDefaultValue() ||
-                twoFerSolution.ReturnsStringInterpolationWithNullCoalescingOperator())
-            {
-                return twoFerSolution.UsesExpressionBody() ?
-                    twoFerSolution.ApproveAsOptimal() :
-                    twoFerSolution.ApproveWithComment(UseExpressionBodiedMember);
-            }
+            var comments = new List<string>();
 
             if (twoFerSolution.ReturnsStringInterpolationWithIsNullOrEmptyCheck())
-                return twoFerSolution.ApproveWithComment(UseNullCoalescingOperatorNotTernaryOperatorWithIsNullOrEmptyCheck);
+                comments.Add(UseNullCoalescingOperatorNotTernaryOperatorWithIsNullOrEmptyCheck);
 
             if (twoFerSolution.ReturnsStringInterpolationWithIsNullOrWhiteSpaceCheck())
-                return twoFerSolution.ApproveWithComment(UseNullCoalescingOperatorNotTernaryOperatorWithIsNullOrWhiteSpaceCheck);
+                comments.Add(UseNullCoalescingOperatorNotTernaryOperatorWithIsNullOrWhiteSpaceCheck);
 
             if (twoFerSolution.ReturnsStringInterpolationWithNullCheck())
-                return twoFerSolution.ApproveWithComment(UseNullCoalescingOperatorNotTernaryOperatorWithNullCheck);
+                comments.Add(UseNullCoalescingOperatorNotTernaryOperatorWithNullCheck);
 
             if (twoFerSolution.ReturnsStringConcatenation())
-                return twoFerSolution.ApproveWithComment(UseStringInterpolationNotStringConcatenation);
+                comments.Add(UseStringInterpolationNotStringConcatenation);
 
             if (twoFerSolution.ReturnsStringFormat())
-                return twoFerSolution.ApproveWithComment(UseStringInterpolationNotStringFormat);
+                comments.Add(UseStringInterpolationNotStringFormat);
+
+            if (!twoFerSolution.UsesExpressionBody())
+                comments.Add(UseExpressionBodiedMember);
+
+            if (comments.Any())
+                return twoFerSolution.ApproveWithComment(comments.ToArray());
+
+            if (twoFerSolution.ReturnsStringInterpolationWithDefaultValue() ||
+                    twoFerSolution.ReturnsStringInterpolationWithNullCoalescingOperator())
+                return twoFerSolution.ApproveAsOptimal();
 
             return null;
         }
@@ -84,32 +92,37 @@ namespace Exercism.Analyzers.CSharp.Analyzers.TwoFer
             if (!twoFerSolution.AssignsToParameter())
                 return null;
 
+            var comments = new List<string>();
+
             if (!twoFerSolution.AssignsParameterUsingKnownExpression())
                 return twoFerSolution.ReferToMentor();
 
             if (twoFerSolution.ReturnsStringFormat())
-                return twoFerSolution.ApproveWithComment(UseStringInterpolationNotStringFormat);
+                comments.Add(UseStringInterpolationNotStringFormat);
 
             if (twoFerSolution.ReturnsStringConcatenation())
-                return twoFerSolution.ApproveWithComment(UseStringInterpolationNotStringConcatenation);
-
-            if (!twoFerSolution.ReturnsStringInterpolation())
-                return null;
+                comments.Add(UseStringInterpolationNotStringConcatenation);
 
             if (twoFerSolution.AssignsParameterUsingNullCoalescingOperator())
-                return twoFerSolution.ApproveWithComment(ReturnImmediately);
+                comments.Add(ReturnImmediately);
 
             if (twoFerSolution.AssignsParameterUsingNullCheck() ||
                 twoFerSolution.AssignsParameterUsingIfNullCheck())
-                return twoFerSolution.ApproveWithComment(UseNullCoalescingOperatorNotNullCheck);
+                comments.Add(UseNullCoalescingOperatorNotNullCheck);
 
             if (twoFerSolution.AssignsParameterUsingIsNullOrEmptyCheck() ||
                 twoFerSolution.AssignsParameterUsingIfIsNullOrEmptyCheck())
-                return twoFerSolution.ApproveWithComment(UseNullCoalescingOperatorNotIsNullOrEmptyCheck);
+                comments.Add(UseNullCoalescingOperatorNotIsNullOrEmptyCheck);
 
             if (twoFerSolution.AssignsParameterUsingIsNullOrWhiteSpaceCheck() ||
                 twoFerSolution.AssignsParameterUsingIfIsNullOrWhiteSpaceCheck())
-                return twoFerSolution.ApproveWithComment(UseNullCoalescingOperatorNotIsNullOrWhiteSpaceCheck);
+                comments.Add(UseNullCoalescingOperatorNotIsNullOrWhiteSpaceCheck);
+
+            if (comments.Any())
+                return twoFerSolution.ApproveWithComment(comments.ToArray());
+
+            if (twoFerSolution.ReturnsStringInterpolation())
+                return twoFerSolution.ApproveAsOptimal();
 
             return null;
         }
@@ -119,29 +132,32 @@ namespace Exercism.Analyzers.CSharp.Analyzers.TwoFer
             if (!twoFerSolution.AssignsVariable())
                 return null;
 
+            var comments = new List<string>();
+
             if (!twoFerSolution.AssignsVariableUsingKnownInitializer())
                 return twoFerSolution.ReferToMentor();
 
             if (twoFerSolution.ReturnsStringFormatWithVariable())
-                return twoFerSolution.ApproveWithComment(UseStringInterpolationNotStringFormat);
+                comments.Add(UseStringInterpolationNotStringFormat);
 
             if (twoFerSolution.ReturnsStringConcatenationWithVariable())
-                return twoFerSolution.ApproveWithComment(UseStringInterpolationNotStringConcatenation);
-
-            if (!twoFerSolution.ReturnsStringInterpolationWithVariable())
-                return null;
-
-            if (twoFerSolution.AssignsVariableUsingNullCoalescingOperator())
-                return twoFerSolution.ApproveAsOptimal();
+                comments.Add(UseStringInterpolationNotStringConcatenation);
 
             if (twoFerSolution.AssignsVariableUsingNullCheck())
-                return twoFerSolution.ApproveWithComment(UseNullCoalescingOperatorNotTernaryOperatorWithNullCheck);
+                comments.Add(UseNullCoalescingOperatorNotTernaryOperatorWithNullCheck);
 
             if (twoFerSolution.AssignsVariableUsingIsNullOrEmptyCheck())
-                return twoFerSolution.ApproveWithComment(UseNullCoalescingOperatorNotTernaryOperatorWithIsNullOrEmptyCheck);
+                comments.Add(UseNullCoalescingOperatorNotTernaryOperatorWithIsNullOrEmptyCheck);
 
             if (twoFerSolution.AssignsVariableUsingIsNullOrWhiteSpaceCheck())
-                return twoFerSolution.ApproveWithComment(UseNullCoalescingOperatorNotTernaryOperatorWithIsNullOrWhiteSpaceCheck);
+                comments.Add(UseNullCoalescingOperatorNotTernaryOperatorWithIsNullOrWhiteSpaceCheck);
+
+            if (comments.Any())
+                return twoFerSolution.ApproveWithComment(comments.ToArray());
+
+            if (twoFerSolution.ReturnsStringInterpolationWithVariable() &&
+                twoFerSolution.AssignsVariableUsingNullCoalescingOperator())
+                return twoFerSolution.ApproveAsOptimal();
 
             return null;
         }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/ExerciseAnalyzerTests.cs
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/ExerciseAnalyzerTests.cs
@@ -10,11 +10,8 @@ namespace Exercism.Analyzers.CSharp.IntegrationTests
         {
             var analysisRun = TestSolutionAnalyzer.Run(testSolution);
 
-            Assert.True(analysisRun.Expected.Status == analysisRun.Actual.Status, testSolution.Directory);
-            foreach(var expectedComment in analysisRun.Expected.Comments)
-            {
-                Assert.Contains(expectedComment, analysisRun.Actual.Comments);
-            }
+            Assert.Equal(analysisRun.Expected.Status, analysisRun.Actual.Status);
+            Assert.Equal(analysisRun.Expected.Comments, analysisRun.Actual.Comments);
         }
     }
 }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/ExerciseAnalyzerTests.cs
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/ExerciseAnalyzerTests.cs
@@ -5,13 +5,16 @@ namespace Exercism.Analyzers.CSharp.IntegrationTests
     public class ExerciseAnalyzerTests
     {
         [Theory]
-        [TestSolutionsDataAttribute]
+        [TestSolutionsData]
         public void SolutionShouldBeCorrectlyAnalyzed(TestSolution testSolution)
         {
             var analysisRun = TestSolutionAnalyzer.Run(testSolution);
 
-            Assert.Equal(analysisRun.Expected.Status, analysisRun.Actual.Status);
-            Assert.Equal(analysisRun.Expected.Comments, analysisRun.Actual.Comments);
+            Assert.True(analysisRun.Expected.Status == analysisRun.Actual.Status, testSolution.Directory);
+            foreach(var expectedComment in analysisRun.Expected.Comments)
+            {
+                Assert.Contains(expectedComment, analysisRun.Actual.Comments);
+            }
         }
     }
 }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Concatenation/Default/Block/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Concatenation/Default/Block/expected_analysis.json
@@ -1,4 +1,7 @@
 {
-  "status": "approve_with_comment", 
-  "comments": ["csharp.general.use_string_interpolation_not_string_concatenation"]
+    "status": "approve_with_comment",
+    "comments": [
+        "csharp.general.use_string_interpolation_not_string_concatenation",
+        "csharp.general.use_expression_bodied_member"
+    ]
 }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Concatenation/IsNullOrEmpty/Block/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Concatenation/IsNullOrEmpty/Block/expected_analysis.json
@@ -1,4 +1,7 @@
 {
-  "status": "approve_with_comment",
-  "comments": ["csharp.general.use_string_interpolation_not_string_concatenation"]
+    "status": "approve_with_comment",
+    "comments": [
+        "csharp.general.use_string_interpolation_not_string_concatenation",
+        "csharp.general.use_expression_bodied_member"
+    ]
 }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Concatenation/IsNullOrEmpty/ParameterIf/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Concatenation/IsNullOrEmpty/ParameterIf/expected_analysis.json
@@ -1,4 +1,7 @@
 {
-  "status": "approve_with_comment",
-  "comments": ["csharp.general.use_string_interpolation_not_string_concatenation"]
+    "status": "approve_with_comment",
+    "comments": [
+        "csharp.general.use_string_interpolation_not_string_concatenation",
+        "csharp.two-fer.use_null_coalescing_operator_not_is_null_or_empty"
+    ]
 }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Concatenation/IsNullOrEmpty/ParameterTernary/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Concatenation/IsNullOrEmpty/ParameterTernary/expected_analysis.json
@@ -1,4 +1,7 @@
 {
-  "status": "approve_with_comment",
-  "comments": ["csharp.general.use_string_interpolation_not_string_concatenation"]
+    "status": "approve_with_comment",
+    "comments": [
+        "csharp.general.use_string_interpolation_not_string_concatenation",
+        "csharp.two-fer.use_null_coalescing_operator_not_is_null_or_empty"
+    ]
 }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Concatenation/IsNullOrEmpty/Variable/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Concatenation/IsNullOrEmpty/Variable/expected_analysis.json
@@ -1,4 +1,7 @@
 {
-  "status": "approve_with_comment",
-  "comments": ["csharp.general.use_string_interpolation_not_string_concatenation"]
+    "status": "approve_with_comment",
+    "comments": [
+        "csharp.general.use_string_interpolation_not_string_concatenation",
+        "csharp.two-fer.use_null_coalescing_operator_not_ternary_operator_with_is_null_or_empty"
+    ]
 }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Concatenation/IsNullOrWhiteSpace/Block/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Concatenation/IsNullOrWhiteSpace/Block/expected_analysis.json
@@ -1,4 +1,7 @@
 {
-  "status": "approve_with_comment",
-  "comments": ["csharp.general.use_string_interpolation_not_string_concatenation"]
+    "status": "approve_with_comment",
+    "comments": [
+        "csharp.general.use_string_interpolation_not_string_concatenation",
+        "csharp.general.use_expression_bodied_member"
+    ]
 }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Concatenation/IsNullOrWhiteSpace/ParameterIf/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Concatenation/IsNullOrWhiteSpace/ParameterIf/expected_analysis.json
@@ -1,4 +1,7 @@
 {
-  "status": "approve_with_comment",
-  "comments": ["csharp.general.use_string_interpolation_not_string_concatenation"]
+    "status": "approve_with_comment",
+    "comments": [
+        "csharp.general.use_string_interpolation_not_string_concatenation",
+        "csharp.two-fer.use_null_coalescing_operator_not_is_null_or_white_space"
+    ]
 }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Concatenation/IsNullOrWhiteSpace/ParameterTernary/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Concatenation/IsNullOrWhiteSpace/ParameterTernary/expected_analysis.json
@@ -1,4 +1,7 @@
 {
-  "status": "approve_with_comment",
-  "comments": ["csharp.general.use_string_interpolation_not_string_concatenation"]
+    "status": "approve_with_comment",
+    "comments": [
+        "csharp.general.use_string_interpolation_not_string_concatenation",
+        "csharp.two-fer.use_null_coalescing_operator_not_is_null_or_white_space"
+    ]
 }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Concatenation/IsNullOrWhiteSpace/Variable/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Concatenation/IsNullOrWhiteSpace/Variable/expected_analysis.json
@@ -1,4 +1,7 @@
 {
-  "status": "approve_with_comment",
-  "comments": ["csharp.general.use_string_interpolation_not_string_concatenation"]
+    "status": "approve_with_comment",
+    "comments": [
+        "csharp.general.use_string_interpolation_not_string_concatenation",
+        "csharp.two-fer.use_null_coalescing_operator_not_ternary_operator_with_is_null_or_white_space"
+    ]
 }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Concatenation/Null/Block/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Concatenation/Null/Block/expected_analysis.json
@@ -1,4 +1,7 @@
 {
-  "status": "approve_with_comment", 
-  "comments": ["csharp.general.use_string_interpolation_not_string_concatenation"]
+    "status": "approve_with_comment",
+    "comments": [
+        "csharp.general.use_string_interpolation_not_string_concatenation",
+        "csharp.general.use_expression_bodied_member"
+    ]
 }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Concatenation/Null/ParameterIf/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Concatenation/Null/ParameterIf/expected_analysis.json
@@ -1,4 +1,7 @@
 {
-  "status": "approve_with_comment",
-  "comments": ["csharp.general.use_string_interpolation_not_string_concatenation"]
+    "status": "approve_with_comment",
+    "comments": [
+        "csharp.general.use_string_interpolation_not_string_concatenation",
+        "csharp.general.use_null_coalescing_operator_not_null_check"
+    ]
 }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Concatenation/Null/ParameterTernary/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Concatenation/Null/ParameterTernary/expected_analysis.json
@@ -1,4 +1,7 @@
 {
-  "status": "approve_with_comment",
-  "comments": ["csharp.general.use_string_interpolation_not_string_concatenation"]
+    "status": "approve_with_comment",
+    "comments": [
+        "csharp.general.use_string_interpolation_not_string_concatenation",
+        "csharp.general.use_null_coalescing_operator_not_null_check"
+    ]
 }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Concatenation/Null/Variable/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Concatenation/Null/Variable/expected_analysis.json
@@ -1,4 +1,7 @@
 {
-  "status": "approve_with_comment",
-  "comments": ["csharp.general.use_string_interpolation_not_string_format"]
+    "status": "approve_with_comment",
+    "comments": [
+        "csharp.general.use_string_interpolation_not_string_format",
+        "csharp.general.use_null_coalescing_operator_not_ternary_operator_with_null_check"
+    ]
 }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Concatenation/NullCoalescing/Block/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Concatenation/NullCoalescing/Block/expected_analysis.json
@@ -1,4 +1,7 @@
 {
-  "status": "approve_with_comment", 
-  "comments": ["csharp.general.use_string_interpolation_not_string_concatenation"]
+    "status": "approve_with_comment",
+    "comments": [
+        "csharp.general.use_string_interpolation_not_string_concatenation",
+        "csharp.general.use_expression_bodied_member"
+    ]
 }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Concatenation/NullCoalescing/Parameter/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Concatenation/NullCoalescing/Parameter/expected_analysis.json
@@ -1,4 +1,7 @@
 {
-  "status": "approve_with_comment",
-  "comments": ["csharp.general.use_string_interpolation_not_string_concatenation"]
+    "status": "approve_with_comment",
+    "comments": [
+        "csharp.general.use_string_interpolation_not_string_concatenation",
+        "csharp.general.return_immediately"
+    ]
 }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Format/Default/Block/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Format/Default/Block/expected_analysis.json
@@ -1,4 +1,7 @@
 {
-  "status": "approve_with_comment", 
-  "comments": ["csharp.general.use_string_interpolation_not_string_format"]
+    "status": "approve_with_comment",
+    "comments": [
+        "csharp.general.use_string_interpolation_not_string_format",
+        "csharp.general.use_expression_bodied_member"
+    ]
 }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Format/IsNullOrEmpty/Block/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Format/IsNullOrEmpty/Block/expected_analysis.json
@@ -1,4 +1,7 @@
 {
-  "status": "approve_with_comment",
-  "comments": ["csharp.general.use_string_interpolation_not_string_format"]
+    "status": "approve_with_comment",
+    "comments": [
+        "csharp.general.use_string_interpolation_not_string_format",
+        "csharp.general.use_expression_bodied_member"
+    ]
 }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Format/IsNullOrEmpty/ParameterIf/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Format/IsNullOrEmpty/ParameterIf/expected_analysis.json
@@ -1,4 +1,7 @@
 {
-  "status": "approve_with_comment",
-  "comments": ["csharp.general.use_string_interpolation_not_string_format"]
+    "status": "approve_with_comment",
+    "comments": [
+        "csharp.general.use_string_interpolation_not_string_format",
+        "csharp.two-fer.use_null_coalescing_operator_not_is_null_or_empty"
+    ]
 }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Format/IsNullOrEmpty/ParameterTernary/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Format/IsNullOrEmpty/ParameterTernary/expected_analysis.json
@@ -1,4 +1,7 @@
 {
-  "status": "approve_with_comment",
-  "comments": ["csharp.general.use_string_interpolation_not_string_format"]
+    "status": "approve_with_comment",
+    "comments": [
+        "csharp.general.use_string_interpolation_not_string_format",
+        "csharp.two-fer.use_null_coalescing_operator_not_is_null_or_empty"
+    ]
 }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Format/IsNullOrEmpty/Variable/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Format/IsNullOrEmpty/Variable/expected_analysis.json
@@ -1,4 +1,7 @@
 {
-  "status": "approve_with_comment",
-  "comments": ["csharp.general.use_string_interpolation_not_string_format"]
+    "status": "approve_with_comment",
+    "comments": [
+        "csharp.general.use_string_interpolation_not_string_format",
+        "csharp.two-fer.use_null_coalescing_operator_not_ternary_operator_with_is_null_or_empty"
+    ]
 }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Format/IsNullOrWhiteSpace/Block/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Format/IsNullOrWhiteSpace/Block/expected_analysis.json
@@ -1,4 +1,7 @@
 {
-  "status": "approve_with_comment",
-  "comments": ["csharp.general.use_string_interpolation_not_string_format"]
+    "status": "approve_with_comment",
+    "comments": [
+        "csharp.general.use_string_interpolation_not_string_format",
+        "csharp.general.use_expression_bodied_member"
+    ]
 }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Format/IsNullOrWhiteSpace/ParameterIf/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Format/IsNullOrWhiteSpace/ParameterIf/expected_analysis.json
@@ -1,4 +1,7 @@
 {
-  "status": "approve_with_comment",
-  "comments": ["csharp.general.use_string_interpolation_not_string_format"]
+    "status": "approve_with_comment",
+    "comments": [
+        "csharp.general.use_string_interpolation_not_string_format",
+        "csharp.two-fer.use_null_coalescing_operator_not_is_null_or_white_space"
+    ]
 }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Format/IsNullOrWhiteSpace/ParameterTernary/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Format/IsNullOrWhiteSpace/ParameterTernary/expected_analysis.json
@@ -1,4 +1,7 @@
 {
-  "status": "approve_with_comment",
-  "comments": ["csharp.general.use_string_interpolation_not_string_format"]
+    "status": "approve_with_comment",
+    "comments": [
+        "csharp.general.use_string_interpolation_not_string_format",
+        "csharp.two-fer.use_null_coalescing_operator_not_is_null_or_white_space"
+    ]
 }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Format/IsNullOrWhiteSpace/Variable/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Format/IsNullOrWhiteSpace/Variable/expected_analysis.json
@@ -1,4 +1,7 @@
 {
-  "status": "approve_with_comment",
-  "comments": ["csharp.general.use_string_interpolation_not_string_format"]
+    "status": "approve_with_comment",
+    "comments": [
+        "csharp.general.use_string_interpolation_not_string_format",
+        "csharp.two-fer.use_null_coalescing_operator_not_ternary_operator_with_is_null_or_white_space"
+    ]
 }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Format/Null/Block/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Format/Null/Block/expected_analysis.json
@@ -1,4 +1,7 @@
 {
-  "status": "approve_with_comment", 
-  "comments": ["csharp.general.use_string_interpolation_not_string_format"]
+    "status": "approve_with_comment",
+    "comments": [
+        "csharp.general.use_string_interpolation_not_string_format",
+        "csharp.general.use_expression_bodied_member"
+    ]
 }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Format/Null/BlockWithNegativeCheck/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Format/Null/BlockWithNegativeCheck/expected_analysis.json
@@ -1,4 +1,7 @@
 {
-  "status": "approve_with_comment", 
-  "comments": ["csharp.general.use_string_interpolation_not_string_format"]
+    "status": "approve_with_comment",
+    "comments": [
+        "csharp.general.use_string_interpolation_not_string_format",
+        "csharp.general.use_expression_bodied_member"
+    ]
 }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Format/Null/ParameterIf/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Format/Null/ParameterIf/expected_analysis.json
@@ -1,4 +1,7 @@
 {
-  "status": "approve_with_comment", 
-  "comments": ["csharp.general.use_string_interpolation_not_string_format"]
+    "status": "approve_with_comment",
+    "comments": [
+        "csharp.general.use_string_interpolation_not_string_format",
+        "csharp.general.use_null_coalescing_operator_not_null_check"
+    ]
 }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Format/Null/ParameterTernary/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Format/Null/ParameterTernary/expected_analysis.json
@@ -1,4 +1,7 @@
 {
-  "status": "approve_with_comment", 
-  "comments": ["csharp.general.use_string_interpolation_not_string_format"]
+    "status": "approve_with_comment",
+    "comments": [
+        "csharp.general.use_string_interpolation_not_string_format",
+        "csharp.general.use_null_coalescing_operator_not_null_check"
+    ]
 }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Format/Null/Variable/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Format/Null/Variable/expected_analysis.json
@@ -1,4 +1,7 @@
 {
-  "status": "approve_with_comment", 
-  "comments": ["csharp.general.use_string_interpolation_not_string_format"]
+    "status": "approve_with_comment",
+    "comments": [
+        "csharp.general.use_string_interpolation_not_string_format",
+        "csharp.general.use_null_coalescing_operator_not_ternary_operator_with_null_check"
+    ]
 }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Format/NullCoalescing/Block/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Format/NullCoalescing/Block/expected_analysis.json
@@ -1,4 +1,7 @@
 {
-  "status": "approve_with_comment", 
-  "comments": ["csharp.general.use_string_interpolation_not_string_format"]
+    "status": "approve_with_comment",
+    "comments": [
+        "csharp.general.use_string_interpolation_not_string_format",
+        "csharp.general.use_expression_bodied_member"
+    ]
 }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Format/NullCoalescing/BlockFullyQualified/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Format/NullCoalescing/BlockFullyQualified/expected_analysis.json
@@ -1,4 +1,7 @@
 {
-  "status": "approve_with_comment", 
-  "comments": ["csharp.general.use_string_interpolation_not_string_format"]
+    "status": "approve_with_comment",
+    "comments": [
+        "csharp.general.use_string_interpolation_not_string_format",
+        "csharp.general.use_expression_bodied_member"
+    ]
 }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Interpolation/IsNullOrEmpty/Block/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Interpolation/IsNullOrEmpty/Block/expected_analysis.json
@@ -1,4 +1,7 @@
 {
-  "status": "approve_with_comment", 
-  "comments": ["csharp.two-fer.use_null_coalescing_operator_not_ternary_operator_with_is_null_or_empty"]
+    "status": "approve_with_comment",
+    "comments": [
+        "csharp.two-fer.use_null_coalescing_operator_not_ternary_operator_with_is_null_or_empty",
+        "csharp.general.use_expression_bodied_member"
+    ]
 }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Interpolation/IsNullOrWhiteSpace/Block/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Interpolation/IsNullOrWhiteSpace/Block/expected_analysis.json
@@ -1,4 +1,7 @@
 {
-  "status": "approve_with_comment", 
-  "comments": ["csharp.two-fer.use_null_coalescing_operator_not_ternary_operator_with_is_null_or_white_space"]
+    "status": "approve_with_comment",
+    "comments": [
+        "csharp.two-fer.use_null_coalescing_operator_not_ternary_operator_with_is_null_or_white_space",
+        "csharp.general.use_expression_bodied_member"
+    ]
 }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Interpolation/Null/Block/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Interpolation/Null/Block/expected_analysis.json
@@ -1,4 +1,7 @@
 {
-  "status": "approve_with_comment", 
-  "comments": ["csharp.general.use_null_coalescing_operator_not_ternary_operator_with_null_check"]
+    "status": "approve_with_comment",
+    "comments": [
+        "csharp.general.use_null_coalescing_operator_not_ternary_operator_with_null_check",
+        "csharp.general.use_expression_bodied_member"
+    ]
 }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Interpolation/Null/BlockWithRedundantParentheses/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Interpolation/Null/BlockWithRedundantParentheses/expected_analysis.json
@@ -1,4 +1,7 @@
 {
-  "status": "approve_with_comment", 
-  "comments": ["csharp.general.use_null_coalescing_operator_not_ternary_operator_with_null_check"]
+    "status": "approve_with_comment",
+    "comments": [
+        "csharp.general.use_null_coalescing_operator_not_ternary_operator_with_null_check",
+        "csharp.general.use_expression_bodied_member"
+    ]
 }


### PR DESCRIPTION
As discussed in #38. This PR changes the two-fer analyzer to return multiple comments instead of one. The analyser uses two stages to return comments. First all comments that lead to a disprove. Only if a solution passes these tests it will give comments that lead to to a approve with comments.

I changed the unit tests so it tests only if the expected comment is given, it does not check all the comments. I did this so the unit tests keeps testing only a specific part of the code.