### PR TITLE
Return multiple comments for gigasecond

### DIFF
--- a/src/Exercism.Analyzers.CSharp/Analyzers/Gigasecond/GigasecondAnalyzer.cs
+++ b/src/Exercism.Analyzers.CSharp/Analyzers/Gigasecond/GigasecondAnalyzer.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Linq;
 using static Exercism.Analyzers.CSharp.Analyzers.Gigasecond.GigasecondComments;
 using static Exercism.Analyzers.CSharp.Analyzers.Shared.SharedComments;
 
@@ -15,51 +17,55 @@ namespace Exercism.Analyzers.CSharp.Analyzers.Gigasecond
 
         private static SolutionAnalysis DisapproveWhenInvalid(this GigasecondSolution gigasecondSolution)
         {
+            var comments = new List<string>();
+
             if (gigasecondSolution.CreatesNewDatetime())
-                return gigasecondSolution.DisapproveWithComment(DontCreateDateTime);
+                comments.Add(DontCreateDateTime);
             
             if (gigasecondSolution.DoesNotUseAddSeconds())
-                return gigasecondSolution.DisapproveWithComment(UseAddSeconds);
+                comments.Add(UseAddSeconds);
 
-            return null;
+            return comments.Any() ? gigasecondSolution.DisapproveWithComment(comments.ToArray()) : null;
         }
 
         private static SolutionAnalysis ApproveWhenValid(this GigasecondSolution gigasecondSolution)
         {
+            var comments = new List<string>();
+
             if (gigasecondSolution.UsesMathPow())
-                return gigasecondSolution.ApproveWithComment(UseScientificNotationNotMathPow);
+                comments.Add(UseScientificNotationNotMathPow);
 
             if (gigasecondSolution.UsesDigitsWithoutSeparator())
-                return gigasecondSolution.ApproveWithComment(UseScientificNotationOrDigitSeparators);
-
-            if (!gigasecondSolution.UsesScientificNotation() &&
-                !gigasecondSolution.UsesDigitsWithSeparator())
-                return null;
+                comments.Add(UseScientificNotationOrDigitSeparators);
 
             if (gigasecondSolution.AssignsToParameterAndReturns() ||
                 gigasecondSolution.AssignsToVariableAndReturns())
-                return gigasecondSolution.ApproveWithComment(ReturnImmediately);
-            
-            if (gigasecondSolution.UsesLocalConstVariable())
-                return gigasecondSolution.ApproveAsOptimal();
+                comments.Add(ReturnImmediately);
                     
-            if (gigasecondSolution.UsesLocalVariable())
-                return gigasecondSolution.ApproveWithComment(UseConstant);
+            if (gigasecondSolution.UsesLocalVariable() &&
+                !gigasecondSolution.UsesLocalConstVariable())
+                comments.Add(UseConstant);
+                
+            if (gigasecondSolution.UsesField() &&
+                !gigasecondSolution.UsesConstField())
+                comments.Add(UseConstant);
 
-            if (gigasecondSolution.UsesPrivateConstField())
-                return gigasecondSolution.UsesExpressionBody()
-                    ? gigasecondSolution.ApproveAsOptimal()
-                    : gigasecondSolution.ApproveWithComment(UseExpressionBodiedMember);
+            if (gigasecondSolution.UsesField() &&
+                !gigasecondSolution.UsesPrivateField())
+                comments.Add(UsePrivateVisibility);
 
-            if (gigasecondSolution.UsesConstField())
-                return gigasecondSolution.ApproveWithComment(UsePrivateVisibility);
-            
-            if (gigasecondSolution.UsesField())
-                return gigasecondSolution.ApproveWithComment(UseConstant);
-            
-            return gigasecondSolution.UsesExpressionBody()
-                ? gigasecondSolution.ApproveAsOptimal()
-                : gigasecondSolution.ApproveWithComment(UseExpressionBodiedMember);
+            if (gigasecondSolution.UsesSingleLine() &&
+                !gigasecondSolution.UsesExpressionBody())
+                comments.Add(UseExpressionBodiedMember);
+
+            if (comments.Any())
+                return gigasecondSolution.ApproveWithComment(comments.ToArray());
+
+            if (gigasecondSolution.UsesScientificNotation() ||
+                gigasecondSolution.UsesDigitsWithSeparator())
+                return gigasecondSolution.ApproveAsOptimal();
+
+            return null;
         }
     }
 }

--- a/src/Exercism.Analyzers.CSharp/Analyzers/Gigasecond/GigasecondSolution.cs
+++ b/src/Exercism.Analyzers.CSharp/Analyzers/Gigasecond/GigasecondSolution.cs
@@ -47,6 +47,9 @@ namespace Exercism.Analyzers.CSharp.Analyzers.Gigasecond
         public bool UsesExpressionBody() =>
             _addMethod.IsExpressionBody();
 
+        public bool UsesSingleLine() =>
+            _addMethod.SingleLine();
+
         public bool UsesConstField() =>
             UsesField() &&
             _addSecondsFieldArgument.IsConst();
@@ -55,7 +58,7 @@ namespace Exercism.Analyzers.CSharp.Analyzers.Gigasecond
             UsesPrivateField() &&
             UsesConstField();
 
-        private bool UsesPrivateField() =>
+        public bool UsesPrivateField() =>
             UsesField() &&
             _addSecondsFieldArgument.IsPrivate();
 

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Gigasecond/AddSeconds/DigitsWithSeparator/ArgumentIsPublicConstant/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Gigasecond/AddSeconds/DigitsWithSeparator/ArgumentIsPublicConstant/expected_analysis.json
@@ -1,4 +1,9 @@
 {
+
   "status": "approve_with_comment",
-  "comments": ["csharp.general.use_private_visibility"]
+  "comments": [
+    "csharp.general.use_private_visibility",
+    "csharp.general.use_expression_bodied_member"
+  ]
+
 }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Gigasecond/AddSeconds/DigitsWithSeparator/ArgumentIsStaticField/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Gigasecond/AddSeconds/DigitsWithSeparator/ArgumentIsStaticField/expected_analysis.json
@@ -1,4 +1,9 @@
 {
-  "status": "approve_with_comment", 
-  "comments": ["csharp.general.use_constant"]
+
+  "status": "approve_with_comment",
+  "comments": [
+    "csharp.general.use_constant",
+    "csharp.general.use_expression_bodied_member"
+  ]
+
 }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Gigasecond/AddSeconds/DigitsWithoutSeparator/ArgumentIsConstant/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Gigasecond/AddSeconds/DigitsWithoutSeparator/ArgumentIsConstant/expected_analysis.json
@@ -1,4 +1,9 @@
 {
-  "status": "approve_with_comment", 
-  "comments": ["csharp.gigasecond.use_1e9_or_digit_separator"]
+
+  "status": "approve_with_comment",
+  "comments": [
+    "csharp.gigasecond.use_1e9_or_digit_separator",
+    "csharp.general.use_expression_bodied_member"
+  ]
+
 }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Gigasecond/AddSeconds/DigitsWithoutSeparator/ArgumentIsStaticField/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Gigasecond/AddSeconds/DigitsWithoutSeparator/ArgumentIsStaticField/expected_analysis.json
@@ -1,4 +1,10 @@
 {
-  "status": "approve_with_comment", 
-  "comments": ["csharp.gigasecond.use_1e9_or_digit_separator"]
+
+  "status": "approve_with_comment",
+  "comments": [
+    "csharp.gigasecond.use_1e9_or_digit_separator",
+    "csharp.general.use_constant",
+    "csharp.general.use_expression_bodied_member"
+  ]
+
 }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Gigasecond/AddSeconds/DigitsWithoutSeparator/ArgumentIsVariable/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Gigasecond/AddSeconds/DigitsWithoutSeparator/ArgumentIsVariable/expected_analysis.json
@@ -1,4 +1,9 @@
 {
-  "status": "approve_with_comment", 
-  "comments": ["csharp.gigasecond.use_1e9_or_digit_separator"]
+
+  "status": "approve_with_comment",
+  "comments": [
+    "csharp.gigasecond.use_1e9_or_digit_separator",
+    "csharp.general.use_constant"
+  ]
+
 }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Gigasecond/AddSeconds/DigitsWithoutSeparator/Block/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Gigasecond/AddSeconds/DigitsWithoutSeparator/Block/expected_analysis.json
@@ -1,4 +1,9 @@
 {
-  "status": "approve_with_comment", 
-  "comments": ["csharp.gigasecond.use_1e9_or_digit_separator"]
+
+  "status": "approve_with_comment",
+  "comments": [
+    "csharp.gigasecond.use_1e9_or_digit_separator",
+    "csharp.general.use_expression_bodied_member"
+  ]
+
 }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Gigasecond/AddSeconds/DigitsWithoutSeparator/Parameter/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Gigasecond/AddSeconds/DigitsWithoutSeparator/Parameter/expected_analysis.json
@@ -1,4 +1,9 @@
 {
-  "status": "approve_with_comment", 
-  "comments": ["csharp.gigasecond.use_1e9_or_digit_separator"]
+
+  "status": "approve_with_comment",
+  "comments": [
+    "csharp.gigasecond.use_1e9_or_digit_separator",
+    "csharp.general.return_immediately"
+  ]
+
 }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Gigasecond/AddSeconds/DigitsWithoutSeparator/Variable/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Gigasecond/AddSeconds/DigitsWithoutSeparator/Variable/expected_analysis.json
@@ -1,4 +1,9 @@
 {
-  "status": "approve_with_comment", 
-  "comments": ["csharp.gigasecond.use_1e9_or_digit_separator"]
+
+  "status": "approve_with_comment",
+  "comments": [
+    "csharp.gigasecond.use_1e9_or_digit_separator",
+    "csharp.general.return_immediately"
+  ]
+
 }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Gigasecond/AddSeconds/MathPow/ArgumentIsPrivateStaticField/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Gigasecond/AddSeconds/MathPow/ArgumentIsPrivateStaticField/expected_analysis.json
@@ -1,4 +1,10 @@
 {
-  "status": "approve_with_comment", 
-  "comments": ["csharp.gigasecond.use_1e9_not_math_pow"]
+
+  "status": "approve_with_comment",
+  "comments": [
+    "csharp.gigasecond.use_1e9_not_math_pow",
+    "csharp.general.use_constant",
+    "csharp.general.use_expression_bodied_member"
+  ]
+
 }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Gigasecond/AddSeconds/MathPow/ArgumentIsPrivateStaticReadOnlyField/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Gigasecond/AddSeconds/MathPow/ArgumentIsPrivateStaticReadOnlyField/expected_analysis.json
@@ -1,4 +1,10 @@
 {
+
   "status": "approve_with_comment",
-  "comments": ["csharp.gigasecond.use_1e9_not_math_pow"]
+  "comments": [
+    "csharp.gigasecond.use_1e9_not_math_pow",
+    "csharp.general.use_constant",
+    "csharp.general.use_expression_bodied_member"
+  ]
+
 }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Gigasecond/AddSeconds/MathPow/ArgumentIsPublicStaticField/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Gigasecond/AddSeconds/MathPow/ArgumentIsPublicStaticField/expected_analysis.json
@@ -1,4 +1,11 @@
 {
+
   "status": "approve_with_comment",
-  "comments": ["csharp.gigasecond.use_1e9_not_math_pow"]
+  "comments": [
+    "csharp.gigasecond.use_1e9_not_math_pow",
+    "csharp.general.use_constant",
+    "csharp.general.use_private_visibility",
+    "csharp.general.use_expression_bodied_member"
+  ]
+
 }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Gigasecond/AddSeconds/MathPow/ArgumentIsVariable/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Gigasecond/AddSeconds/MathPow/ArgumentIsVariable/expected_analysis.json
@@ -1,4 +1,9 @@
 {
-  "status": "approve_with_comment", 
-  "comments": ["csharp.gigasecond.use_1e9_not_math_pow"]
+
+  "status": "approve_with_comment",
+  "comments": [
+    "csharp.gigasecond.use_1e9_not_math_pow",
+    "csharp.general.use_constant"
+  ]
+
 }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Gigasecond/AddSeconds/MathPow/Block/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Gigasecond/AddSeconds/MathPow/Block/expected_analysis.json
@@ -1,4 +1,9 @@
 {
+
   "status": "approve_with_comment",
-  "comments": ["csharp.gigasecond.use_1e9_not_math_pow"]
+  "comments": [
+    "csharp.gigasecond.use_1e9_not_math_pow",
+    "csharp.general.use_expression_bodied_member"
+  ]
+
 }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Gigasecond/AddSeconds/MathPow/Parameter/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Gigasecond/AddSeconds/MathPow/Parameter/expected_analysis.json
@@ -1,4 +1,9 @@
 {
+
   "status": "approve_with_comment",
-  "comments": ["csharp.gigasecond.use_1e9_not_math_pow"]
+  "comments": [
+    "csharp.gigasecond.use_1e9_not_math_pow",
+    "csharp.general.return_immediately"
+  ]
+
 }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Gigasecond/AddSeconds/MathPow/Variable/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Gigasecond/AddSeconds/MathPow/Variable/expected_analysis.json
@@ -1,4 +1,9 @@
 {
+
   "status": "approve_with_comment",
-  "comments": ["csharp.gigasecond.use_1e9_not_math_pow"]
+  "comments": [
+    "csharp.gigasecond.use_1e9_not_math_pow",
+    "csharp.general.return_immediately"
+  ]
+
 }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Gigasecond/AddSeconds/ScientificNotation/ArgumentIsPublicConstantBlock/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Gigasecond/AddSeconds/ScientificNotation/ArgumentIsPublicConstantBlock/expected_analysis.json
@@ -1,4 +1,9 @@
 {
+
   "status": "approve_with_comment",
-  "comments": ["csharp.general.use_private_visibility"]
+  "comments": [
+    "csharp.general.use_private_visibility",
+    "csharp.general.use_expression_bodied_member"
+  ]
+
 }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Gigasecond/AddSeconds/ScientificNotation/ArgumentIsStaticField/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Gigasecond/AddSeconds/ScientificNotation/ArgumentIsStaticField/expected_analysis.json
@@ -1,4 +1,9 @@
 {
-  "status": "approve_with_comment", 
-  "comments": ["csharp.general.use_constant"]
+
+  "status": "approve_with_comment",
+  "comments": [
+    "csharp.general.use_constant",
+    "csharp.general.use_expression_bodied_member"
+  ]
+
 }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Gigasecond/Invalid/CreateDateTime/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Gigasecond/Invalid/CreateDateTime/expected_analysis.json
@@ -1,4 +1,9 @@
 {
-  "status": "disapprove_with_comment", 
-  "comments": ["csharp.gigasecond.dont_create_datetime"]
+
+  "status": "disapprove_with_comment",
+  "comments": [
+    "csharp.gigasecond.dont_create_datetime",
+    "csharp.gigasecond.use_add_seconds"
+  ]
+
 }


### PR DESCRIPTION
As discussed in #38. This PR changes the gigasecond analyzer to return multiple comments instead of one.