### PR TITLE
Disapprove leap solutions when DateTime.IsLeapYear is used

### DIFF
--- a/src/Exercism.Analyzers.CSharp/Analyzers/Leap/LeapAnalyzer.cs
+++ b/src/Exercism.Analyzers.CSharp/Analyzers/Leap/LeapAnalyzer.cs
@@ -7,7 +7,7 @@ namespace Exercism.Analyzers.CSharp.Analyzers.Leap
     internal static class LeapAnalyzer
     {
         public static SolutionAnalysis Analyze(ParsedSolution parsedSolution) =>
-            Analyze(new LeapSolution(parsedSolution));
+            Analyze(LeapSolutionParser.Parse(parsedSolution));
 
         private static SolutionAnalysis Analyze(LeapSolution twoFerSolution) =>
             twoFerSolution.DisapproveWhenInvalid() ??
@@ -17,6 +17,9 @@ namespace Exercism.Analyzers.CSharp.Analyzers.Leap
         private static SolutionAnalysis DisapproveWhenInvalid(this LeapSolution leapSolution)
         {
             var comments = new List<string>();
+
+            if (leapSolution.UsesDateTimeIsLeapYear())
+                 comments.Add(LeapComments.DoNotUseIsLeapYear);
 
             if (leapSolution.UsesTooManyChecks())
                 comments.Add(LeapComments.UseMinimumNumberOfChecks);

--- a/src/Exercism.Analyzers.CSharp/Analyzers/Leap/LeapComments.cs
+++ b/src/Exercism.Analyzers.CSharp/Analyzers/Leap/LeapComments.cs
@@ -2,6 +2,7 @@ namespace Exercism.Analyzers.CSharp.Analyzers.Leap
 {
     internal static class LeapComments
     {
+        public const string DoNotUseIsLeapYear = "csharp.leap.do_not_use_is_leap_year";
         public const string UseMinimumNumberOfChecks = "csharp.leap.use_minimum_number_of_checks";
     }
 }

--- a/src/Exercism.Analyzers.CSharp/Analyzers/Leap/LeapSolution.cs
+++ b/src/Exercism.Analyzers.CSharp/Analyzers/Leap/LeapSolution.cs
@@ -1,4 +1,3 @@
-using Exercism.Analyzers.CSharp.Analyzers.Syntax;
 using Exercism.Analyzers.CSharp.Analyzers.Syntax.Comparison;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -7,17 +6,20 @@ namespace Exercism.Analyzers.CSharp.Analyzers.Leap
 {
     internal class LeapSolution : ParsedSolution
     {
-        public MethodDeclarationSyntax IsLeapYearMethod { get; }
-        public ParameterSyntax YearParameter { get; }
-        public ExpressionSyntax ReturnedExpression { get; }
+        public readonly ParameterSyntax YearParameter;
+        public readonly MethodDeclarationSyntax IsLeapYearMethod;
+        public readonly SyntaxNode ReturnExpression;
 
-        public LeapSolution(ParsedSolution solution) : base(solution.Solution, solution.SyntaxRoot)
+        public LeapSolution(ParsedSolution solution,
+            MethodDeclarationSyntax isLeapYearMethod,
+            ParameterSyntax yearParameter,
+            SyntaxNode returnExpression) : base(solution.Solution, solution.SyntaxRoot)
         {
-            IsLeapYearMethod = solution.SyntaxRoot.GetClassMethod("Leap", "IsLeapYear");
-            YearParameter = IsLeapYearMethod.ParameterList?.Parameters.FirstOrDefault();
-            ReturnedExpression = IsLeapYearMethod?.ReturnedExpression();
+            YearParameter = yearParameter;
+            IsLeapYearMethod = isLeapYearMethod;
+            ReturnExpression = returnExpression;
         }
 
-        public bool Returns(SyntaxNode returned) => ReturnedExpression.IsEquivalentWhenNormalized(returned);
+        public bool Returns(SyntaxNode returned) => ReturnExpression.IsEquivalentWhenNormalized(returned);
     }
 }

--- a/src/Exercism.Analyzers.CSharp/Analyzers/Leap/LeapSolutionParser.cs
+++ b/src/Exercism.Analyzers.CSharp/Analyzers/Leap/LeapSolutionParser.cs
@@ -1,0 +1,27 @@
+﻿using Exercism.Analyzers.CSharp.Analyzers.Syntax;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Exercism.Analyzers.CSharp.Analyzers.Leap
+{
+    internal static class LeapSolutionParser
+    {
+        public static LeapSolution Parse(ParsedSolution solution)
+        {
+            var leapClass = solution.LeapClass();
+            var isLeapYearMethod = leapClass.IsLeapYearMethod();
+            var yearParameter = isLeapYearMethod.YearParameter();
+            var returnedExpression = isLeapYearMethod.ReturnedExpression();
+
+            return new LeapSolution(solution, isLeapYearMethod, yearParameter, returnedExpression);
+        }
+
+        private static ClassDeclarationSyntax LeapClass(this ParsedSolution solution) =>
+            solution.SyntaxRoot.GetClass("Leap");
+
+        private static MethodDeclarationSyntax IsLeapYearMethod(this ClassDeclarationSyntax leapClass) =>
+            leapClass?.GetMethod("IsLeapYear");
+
+        private static ParameterSyntax YearParameter(this MethodDeclarationSyntax isLeapYearMethod) =>
+            isLeapYearMethod.ParameterList?.Parameters.FirstOrDefault();
+    }
+}

--- a/src/Exercism.Analyzers.CSharp/Analyzers/Leap/LeapSyntax.cs
+++ b/src/Exercism.Analyzers.CSharp/Analyzers/Leap/LeapSyntax.cs
@@ -3,12 +3,17 @@ using Exercism.Analyzers.CSharp.Analyzers.Syntax;
 using Exercism.Analyzers.CSharp.Analyzers.Syntax.Comparison;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using static Exercism.Analyzers.CSharp.Analyzers.Leap.LeapSyntaxFactory;
+using static Exercism.Analyzers.CSharp.Analyzers.Shared.SharedSyntaxFactory;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Exercism.Analyzers.CSharp.Analyzers.Leap
 {
     internal static class LeapSyntax
     {
         private const int MinimalNumberOfChecks = 3;
+
+        public static bool UsesDateTimeIsLeapYear(this LeapSolution leapSolution) =>
+            leapSolution.IsLeapYearMethod.InvokesMethod(DateTimeMemberAccessExpression(IdentifierName("IsLeapYear")));
 
         public static bool ReturnsMinimumNumberOfChecksInSingleExpression(this LeapSolution leapSolution) =>
             leapSolution.Returns(LeapMinimumNumberOfChecksWithoutParenthesesBinaryExpression(leapSolution)) ||

--- a/src/Exercism.Analyzers.CSharp/Analyzers/Shared/SharedSyntaxFactory.cs
+++ b/src/Exercism.Analyzers.CSharp/Analyzers/Shared/SharedSyntaxFactory.cs
@@ -49,6 +49,9 @@ namespace Exercism.Analyzers.CSharp.Analyzers.Shared
         public static MemberAccessExpressionSyntax StringMemberAccessExpression(IdentifierNameSyntax name) =>
             SimpleMemberAccessExpression(PredefinedType(Token(SyntaxKind.StringKeyword)), name);
 
+        public static MemberAccessExpressionSyntax DateTimeMemberAccessExpression(IdentifierNameSyntax name) =>
+            SimpleMemberAccessExpression(SyntaxFactory.IdentifierName("DateTime"), name);
+
         public static MemberAccessExpressionSyntax SimpleMemberAccessExpression(ExpressionSyntax expression, IdentifierNameSyntax name) =>
             MemberAccessExpression(
                 SyntaxKind.SimpleMemberAccessExpression,

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Leap/UseIsLeapYear/BlockBody/Leap.cs
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Leap/UseIsLeapYear/BlockBody/Leap.cs
@@ -1,0 +1,7 @@
+public static class Leap
+{
+    public static bool IsLeapYear(int year)
+    {
+        return DateTime.IsLeapYear(year);
+    }
+}

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Leap/UseIsLeapYear/BlockBody/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Leap/UseIsLeapYear/BlockBody/expected_analysis.json
@@ -1,0 +1,4 @@
+{
+  "status": "disapprove_with_comment",
+  "comments": [ "csharp.leap.do_not_use_is_leap_year" ]
+}

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Leap/UseIsLeapYear/ExpressionBody/Leap.cs
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Leap/UseIsLeapYear/ExpressionBody/Leap.cs
@@ -1,0 +1,5 @@
+public static class Leap
+{
+    public static bool IsLeapYear(int year) =>
+        DateTime.IsLeapYear(year);
+}

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Leap/UseIsLeapYear/ExpressionBody/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Leap/UseIsLeapYear/ExpressionBody/expected_analysis.json
@@ -1,0 +1,4 @@
+{
+  "status": "disapprove_with_comment",
+  "comments": [ "csharp.leap.do_not_use_is_leap_year" ]
+}


### PR DESCRIPTION
For solutions to the leap exercise usage of the DateTime.IsLeapYear method is not allowed. This PR implements functionality for the leap analyzer that disapprove solution that use this method.