### PR TITLE
Disapprove leap when if statement are used.

### DIFF
--- a/src/Exercism.Analyzers.CSharp/Analyzers/Leap/LeapAnalyzer.cs
+++ b/src/Exercism.Analyzers.CSharp/Analyzers/Leap/LeapAnalyzer.cs
@@ -21,8 +21,8 @@ namespace Exercism.Analyzers.CSharp.Analyzers.Leap
             if (leapSolution.UsesDateTimeIsLeapYear())
                  comments.Add(LeapComments.DoNotUseIsLeapYear);
 
-            if (leapSolution.UsesIfStatement())
-                comments.Add(LeapComments.DoNotUseIfStatement);
+            if (leapSolution.UsesNestedIfStatement())
+                comments.Add(LeapComments.DoNotUseNestedIfStatement);
 
             if (leapSolution.UsesTooManyChecks())
                 comments.Add(LeapComments.UseMinimumNumberOfChecks);
@@ -34,7 +34,10 @@ namespace Exercism.Analyzers.CSharp.Analyzers.Leap
         {
             var comments = new List<string>();
 
-            if (!leapSolution.UsesExpressionBody())
+            if (leapSolution.UsesIfStatement())
+                comments.Add(LeapComments.DoNotUseIfStatement);
+
+            if (leapSolution.UsesSingleLine() && !leapSolution.UsesExpressionBody())
                 comments.Add(SharedComments.UseExpressionBodiedMember);
 
             if (comments.Any())

--- a/src/Exercism.Analyzers.CSharp/Analyzers/Leap/LeapAnalyzer.cs
+++ b/src/Exercism.Analyzers.CSharp/Analyzers/Leap/LeapAnalyzer.cs
@@ -21,6 +21,9 @@ namespace Exercism.Analyzers.CSharp.Analyzers.Leap
             if (leapSolution.UsesDateTimeIsLeapYear())
                  comments.Add(LeapComments.DoNotUseIsLeapYear);
 
+            if (leapSolution.UsesIfStatement())
+                comments.Add(LeapComments.DoNotUseIfStatement);
+
             if (leapSolution.UsesTooManyChecks())
                 comments.Add(LeapComments.UseMinimumNumberOfChecks);
 

--- a/src/Exercism.Analyzers.CSharp/Analyzers/Leap/LeapComments.cs
+++ b/src/Exercism.Analyzers.CSharp/Analyzers/Leap/LeapComments.cs
@@ -3,6 +3,7 @@ namespace Exercism.Analyzers.CSharp.Analyzers.Leap
     internal static class LeapComments
     {
         public const string DoNotUseIsLeapYear = "csharp.leap.do_not_use_is_leap_year";
+        public const string DoNotUseIfStatement = "csharp.leap.do_not_use_if_statement";
         public const string UseMinimumNumberOfChecks = "csharp.leap.use_minimum_number_of_checks";
     }
 }

--- a/src/Exercism.Analyzers.CSharp/Analyzers/Leap/LeapComments.cs
+++ b/src/Exercism.Analyzers.CSharp/Analyzers/Leap/LeapComments.cs
@@ -4,6 +4,7 @@ namespace Exercism.Analyzers.CSharp.Analyzers.Leap
     {
         public const string DoNotUseIsLeapYear = "csharp.leap.do_not_use_is_leap_year";
         public const string DoNotUseIfStatement = "csharp.leap.do_not_use_if_statement";
+        public const string DoNotUseNestedIfStatement = "csharp.leap.do_not_use_nested_if_statement";
         public const string UseMinimumNumberOfChecks = "csharp.leap.use_minimum_number_of_checks";
     }
 }

--- a/src/Exercism.Analyzers.CSharp/Analyzers/Leap/LeapSyntax.cs
+++ b/src/Exercism.Analyzers.CSharp/Analyzers/Leap/LeapSyntax.cs
@@ -42,7 +42,7 @@ namespace Exercism.Analyzers.CSharp.Analyzers.Leap
             leapSolution.IsLeapYearMethod
                 .DescendantNodes()
                 .OfType<IfStatementSyntax>()
-                .Any(_ => _.DescendantNodes()
+                .Any(ifStatement => ifStatement.DescendantNodes()
                     .OfType<IfStatementSyntax>()
                     .Any()
                 );

--- a/src/Exercism.Analyzers.CSharp/Analyzers/Leap/LeapSyntax.cs
+++ b/src/Exercism.Analyzers.CSharp/Analyzers/Leap/LeapSyntax.cs
@@ -20,6 +20,9 @@ namespace Exercism.Analyzers.CSharp.Analyzers.Leap
             leapSolution.Returns(LeapMinimumNumberOfChecksWithoutParenthesesBinaryExpressionReversed(leapSolution)) ||
             leapSolution.Returns(LeapMinimumNumberOfChecksWithParenthesesBinaryExpression(leapSolution));
 
+        public static bool UsesSingleLine(this LeapSolution leapSolution) =>
+            leapSolution.IsLeapYearMethod.SingleLine();
+
         public static bool UsesExpressionBody(this LeapSolution leapSolution) =>
             leapSolution.IsLeapYearMethod.IsExpressionBody();
         
@@ -34,6 +37,15 @@ namespace Exercism.Analyzers.CSharp.Analyzers.Leap
                 .DescendantNodes()
                 .OfType<IfStatementSyntax>()
                 .Any();
+
+        public static bool UsesNestedIfStatement(this LeapSolution leapSolution) =>
+            leapSolution.IsLeapYearMethod
+                .DescendantNodes()
+                .OfType<IfStatementSyntax>()
+                .Any(_ => _.DescendantNodes()
+                    .OfType<IfStatementSyntax>()
+                    .Any()
+                );
 
         private static bool BinaryExpressionUsesYearParameter(this LeapSolution leapSolution, BinaryExpressionSyntax binaryExpression) =>
             binaryExpression.Left.IsEquivalentWhenNormalized(

--- a/src/Exercism.Analyzers.CSharp/Analyzers/Leap/LeapSyntax.cs
+++ b/src/Exercism.Analyzers.CSharp/Analyzers/Leap/LeapSyntax.cs
@@ -29,6 +29,12 @@ namespace Exercism.Analyzers.CSharp.Analyzers.Leap
                 .OfType<BinaryExpressionSyntax>()
                 .Count(leapSolution.BinaryExpressionUsesYearParameter) > MinimalNumberOfChecks;
 
+        public static bool UsesIfStatement(this LeapSolution leapSolution) =>
+            leapSolution.IsLeapYearMethod
+                .DescendantNodes()
+                .OfType<IfStatementSyntax>()
+                .Any();
+
         private static bool BinaryExpressionUsesYearParameter(this LeapSolution leapSolution, BinaryExpressionSyntax binaryExpression) =>
             binaryExpression.Left.IsEquivalentWhenNormalized(
                 LeapParameterIdentifierName(leapSolution)) ||

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Leap/MinimumNumberOfChecks/IfStatement/Leap.cs
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Leap/MinimumNumberOfChecks/IfStatement/Leap.cs
@@ -1,0 +1,20 @@
+public static class Leap
+{
+    public static bool IsLeapYear(int year)
+    {
+        if (year % 4 == 0)
+        {
+            if (year % 100 != 0)
+            {
+                return true;
+            }
+
+            if (year % 400 == 0)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Leap/MinimumNumberOfChecks/IfStatement/Leap.cs
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Leap/MinimumNumberOfChecks/IfStatement/Leap.cs
@@ -2,17 +2,13 @@ public static class Leap
 {
     public static bool IsLeapYear(int year)
     {
-        if (year % 4 == 0)
+        if (year % 4 != 0)
         {
-            if (year % 100 != 0)
-            {
-                return true;
-            }
-
-            if (year % 400 == 0)
-            {
-                return true;
-            }
+            return false;
+        }
+        if (year % 100 != 0 || year % 400 == 0)
+        {
+            return true;
         }
 
         return false;

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Leap/MinimumNumberOfChecks/IfStatement/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Leap/MinimumNumberOfChecks/IfStatement/expected_analysis.json
@@ -1,0 +1,4 @@
+{
+  "status": "disapprove_with_comment", 
+  "comments": ["csharp.leap.do_not_use_if_statement"]
+}

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Leap/MinimumNumberOfChecks/IfStatement/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Leap/MinimumNumberOfChecks/IfStatement/expected_analysis.json
@@ -1,4 +1,4 @@
-{
-  "status": "disapprove_with_comment", 
+﻿{
+  "status": "approve_with_comment", 
   "comments": ["csharp.leap.do_not_use_if_statement"]
 }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Leap/MinimumNumberOfChecks/NestedIfStatement/Leap.cs
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Leap/MinimumNumberOfChecks/NestedIfStatement/Leap.cs
@@ -1,0 +1,20 @@
+public static class Leap
+{
+    public static bool IsLeapYear(int year)
+    {
+        if (year % 4 == 0)
+        {
+            if (year % 100 != 0)
+            {
+                return true;
+            }
+
+            if (year % 400 == 0)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Leap/MinimumNumberOfChecks/NestedIfStatement/expected_analysis.json
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Leap/MinimumNumberOfChecks/NestedIfStatement/expected_analysis.json
@@ -1,0 +1,4 @@
+﻿{
+  "status": "disapprove_with_comment", 
+  "comments": ["csharp.leap.do_not_use_nested_if_statement"]
+}


### PR DESCRIPTION
Students sometimes use submit a solution for the leap exercise that uses if statements. I think these should be disapproved. We could also approve these with a comment, but I think it is best to guide students to using a single logical expression.

An example https://exercism.io/mentor/analyses/2283.