### PR TITLE
[WIP] Compile in memory to detect all compile errors

### DIFF
--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Leap/UseIsLeapYear/BlockBody/Leap.cs
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Leap/UseIsLeapYear/BlockBody/Leap.cs
@@ -1,3 +1,5 @@
+using System;
+
 public static class Leap
 {
     public static bool IsLeapYear(int year)

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Leap/UseIsLeapYear/ExpressionBody/Leap.cs
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/Leap/UseIsLeapYear/ExpressionBody/Leap.cs
@@ -1,3 +1,5 @@
+using System;
+
 public static class Leap
 {
     public static bool IsLeapYear(int year) =>

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Interpolation/IsNullOrWhiteSpace/If/TwoFer.cs
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Interpolation/IsNullOrWhiteSpace/If/TwoFer.cs
@@ -9,6 +9,6 @@ public static class TwoFer
             return "One for you, one for me.";
         }
         else
-            return $"One for {name}, one for me.";
+            return $"One for {input}, one for me.";
     }
 }

--- a/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Join/IsNullOrEmpty/TwoFer.cs
+++ b/test/Exercism.Analyzers.CSharp.IntegrationTests/Solutions/TwoFer/Join/IsNullOrEmpty/TwoFer.cs
@@ -5,7 +5,7 @@ public static class TwoFer
     public static string Speak(string input = null)
     {
         string name = string.IsNullOrEmpty(input) ? "you" : input;
-        var sentence = { "One for ", name, ", one for me."};
+        string[] sentence = { "One for ", name, ", one for me."};
 
         return String.Join("", sentence);
     }


### PR DESCRIPTION
I noticed that compile errors are not always detected. So I am implementing in memory compiling of the submitted solution to detect all compile errors. Even some test solutions had compile errors.

This PR is still work in progress because I have one problem i can't seem to fix. If a solution uses usings the inmemory compile works, but if the solutions uses fully qualified namespaces it does not works and throws errors about missing references. I can't find a solution for this at the moment. Hopefully someone else know a solution.