### PR TITLE
Remove tooling webserver from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,6 @@
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1-alpine AS build
 WORKDIR /app
 
-# Download exercism tooling webserver
-RUN wget -P /usr/local/bin https://github.com/exercism/tooling-webserver/releases/download/0.10.0/tooling_webserver && \
-    chmod +x /usr/local/bin/tooling_webserver
-
 # Copy csproj and restore as distinct layers
 COPY src/Exercism.Analyzers.CSharp/Exercism.Analyzers.CSharp.csproj ./
 RUN dotnet restore -r linux-musl-x64


### PR DESCRIPTION
The tooling webserver has been obsoleted due to https://github.com/exercism/tooling-invoker/pull/29